### PR TITLE
reset bp-activity-oldestpage cookie on page reload

### DIFF
--- a/js/boss-child.js
+++ b/js/boss-child.js
@@ -87,6 +87,21 @@
         parts = url.split("/");
         group_slug = parts[4];
 
+    /** 
+     * Clear the bp-activity-oldestpage cookie on page load to prevent skipping
+     * pages when loading more of an activity feed.
+     *
+     * The cookie is set in buddyboss - /boss/js/buddyboss.js
+     * ```
+     * jq.cookie( 'bp-activity-oldestpage', oldest_page, {
+     *       path: '/'
+     * } );
+     * ```
+     */
+     if( url.indexOf( '/groups/' ) != -1 ) {
+      $.removeCookie('bp-activity-oldestpage', { path: '/' } );
+     }
+
     if( url.indexOf( '/groups/' ) != -1 ) {
       document.body.className = document.body.className.replace("activity","home");
     }


### PR DESCRIPTION
For auto-loading more entries to a group's activity feed, buddyboss uses a cookie to keep track of the last page of items fetched. This is ultimately passed as a page parameter to a wp query. On prod, this cookie gets reset on page reload. On dev, it isn't. As a result, when you scroll down the page and load more entires, it will start off from the oldest entries that were viewed **on the last page load**, so you see big jumps as a result, depending on how far you had scrolled previously.

This is probably related to updating jquery.

This PR adds a call to remove the cookie from bosschild.js.

closes MESH-research/commons#101