### PR TITLE
replace deprecated .live jquery hander with .on

### DIFF
--- a/js/boss-child.js
+++ b/js/boss-child.js
@@ -319,7 +319,7 @@
     }
 
     // we need live() to affect pages of groups loaded via ajax.
-    $('#groups-dir-list .group-button').live('DOMSubtreeModified', joinleave_group_change_handler);
+    $('#groups-dir-list .group-button').on('DOMSubtreeModified', joinleave_group_change_handler);
 
     // groups directory does not run a new query if "back" button was clicked due to browser cache, so force refresh
     // (without this, results on page can be from the wrong tab despite which is "selected")


### PR DESCRIPTION
The .live jQuery function was [deprecated](https://api.jquery.com/live/) in 1.7 and removed in 1.9.  It was replaced with [.on](https://api.jquery.com/on/). The call to .live was causing a crash above the code that registered an event handler for the click event on the Save Changes button for the primary email setting, so the AJAX call was not being made and the data was not being saved.

This PR replaces the .live call with .on, which solves the problem.

Note: I also made this change on production as it was causing problems for users and is small.
 